### PR TITLE
Fix unused parameter

### DIFF
--- a/src/main/kotlin/Kusss.kt
+++ b/src/main/kotlin/Kusss.kt
@@ -125,7 +125,8 @@ object Kusss {
 		if (userToken.isEmpty() || userToken.contains("http")) throw IllegalArgumentException("Invalid token provided")
 		return getExams(
 			URI("https://www.kusss.jku.at/kusss/published-calendar.action?token=${userToken}&lang=de"),
-			calendar
+			calendar,
+			course
 		)
 	}
 	private fun getExams(uri: URI, calendar: Calendar? = null, course : Course): List<Exam?> {


### PR DESCRIPTION
It was likely a copy and paste error, where the parameter was forgotten to add in the call.

Mainly just a compilation warning