### PR TITLE
Add more things to replace for channel name

### DIFF
--- a/src/main/kotlin/CommandManager.kt
+++ b/src/main/kotlin/CommandManager.kt
@@ -630,6 +630,8 @@ class CommandManager : ListenerAdapter() {
 			.lowercase()
 			.replace(" ", "-")
 			.replace("#", "sharp")
+			.replace(".", "dot")
+			.replace("'", "")
 
 		return if (channelName.length < 100) channelName else "${channelName.substring(98)}…"
 	}


### PR DESCRIPTION
Discord does not allow a dot or a `'` in the name