### PR TITLE
Fix substring from too long channel names

### DIFF
--- a/src/main/kotlin/Util.kt
+++ b/src/main/kotlin/Util.kt
@@ -100,7 +100,7 @@ object Util {
 			.replace("'", "")
 
 		return if (limitLength && channelName.length >= 100)
-			"${channelName.substring(98)}…"
+			"${channelName.substring(0, 98)}…"
 		else
 			channelName
 	}


### PR DESCRIPTION
Kotlin's `.substring` does not use a single parameter as the end index. Instead it takes [param, end of string]

Reading the docs/inline hints may be a good idea 