### PR TITLE
Remove double-dash

### DIFF
--- a/src/main/kotlin/Util.kt
+++ b/src/main/kotlin/Util.kt
@@ -94,11 +94,12 @@ object Util {
 			.replace("&amp;", "and")
 			.replace("&", "and")
 			.replace("/", "-")
-			.replace(" ", "-")
 			.replace("#", "sharp")
 			.replace(".", "dot")
 			.replace("'", "")
 			.replace(":", "")
+			.replace(" ", "-")
+			.replace("--", "-")
 
 		return if (limitLength && channelName.length >= 100)
 			"${channelName.substring(0, 98)}…"


### PR DESCRIPTION
Some fixed names may contain double-dashes, which are silently removed by discord.

Not related to this double dash: https://en.wikipedia.org/wiki/Mario_Kart:_Double_Dash